### PR TITLE
Route back to auth after clicking signout

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -33,7 +33,7 @@ class App extends Component {
               className="nav-item-li"
               onClick={this.signOut}>
               <Link
-                to="/create"
+                to="/auth"
                 className="nav-item">
               Sign Out
             </Link>


### PR DESCRIPTION
Route to /auth rather than /create so user is correctly routed to sign-in page after signing out.